### PR TITLE
FIX : timeline 컴포넌트 수정 진행 ( 수정 및 삭제 테스트 완료 )

### DIFF
--- a/components/Atom/TimeLine/TimeLine.tsx
+++ b/components/Atom/TimeLine/TimeLine.tsx
@@ -5,6 +5,7 @@ import * as Styled from './styles';
 import { TimeLineProps } from './types';
 import { EditDropdown, EditDropdownProps } from '@/components/Atom/EditDropdown';
 import { POINT_COLOR, FONT_COLOR, BACKGROUND_COLOR } from '@/constants/color';
+import BlogIcon from '@/components/Atom/BlogIcon';
 
 // [TODO] 최대 글자수 지정 필요
 const TITLE_MAX_LENGTH = 30;
@@ -74,7 +75,7 @@ const TimeLineTitleInput = memo(function TimeLineTitleInput({
         disabled={!!error}
       ></Styled.TimeLineTitleInput>
       <Typo.Label2 color={FONT_COLOR.GRAY_2}>
-        {titleFocus ? `${title.length} / ${titleRef.current?.maxLength}` : ''}
+        {titleFocus ? `${title?.length} / ${titleRef.current?.maxLength}` : ''}
       </Typo.Label2>
     </Styled.TimeLineTitleWrapper>
   );
@@ -106,7 +107,7 @@ const TimeLineDescInput = memo(function TimeLineDescInput({
         disabled={!!error}
       ></Styled.TimeLineDescInput>
       <Typo.Label2 color={FONT_COLOR.GRAY_2}>
-        {descFocus ? `${desc.length} / ${descRef.current?.maxLength}` : ''}
+        {descFocus ? `${desc?.length} / ${descRef.current?.maxLength}` : ''}
       </Typo.Label2>
     </Styled.TimeLineDescWrapper>
   );
@@ -117,7 +118,7 @@ const TimeLine = ({
     date: '',
     title: '',
     desc: '',
-    img: '',
+    url: '',
   },
   onDeleteContent,
   onSaveAllContent,
@@ -160,7 +161,7 @@ const TimeLine = ({
   const onSaveTimeLine = async () => {
     // 추후 API 요청 추가 필요
     try {
-      await onSaveAllContent(timeLineContent);
+      onSaveAllContent(timeLineContent);
     } catch (err) {
       setError('오류가 발생했습니다.');
     } finally {
@@ -201,7 +202,12 @@ const TimeLine = ({
         ></EditDropdown>
       )}
       <TimeLineDate date={timeLineContent?.date}></TimeLineDate>
-      <Styled.TimeLineContent>
+      <Styled.TimeLineContent
+        isEdit={isEdit}
+        onClick={() => {
+          if (!isEdit) window.open(content.url);
+        }}
+      >
         <div>
           {isEdit ? (
             <Styled.TimeLineInputWrapper>
@@ -229,7 +235,7 @@ const TimeLine = ({
             </>
           )}
         </div>
-        <TimeLineImage src={timeLineContent?.img as string} />
+        <BlogIcon url={timeLineContent?.url} />
       </Styled.TimeLineContent>
     </Styled.TimeLineContainer>
   );

--- a/components/Atom/TimeLine/styles.ts
+++ b/components/Atom/TimeLine/styles.ts
@@ -20,12 +20,12 @@ export const TimeLineContainer = styled.div`
   }
 `;
 
-export const TimeLineContent = styled.div`
+export const TimeLineContent = styled.div<{ isEdit: boolean }>`
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
-
+  cursor: ${(props) => (props.isEdit ? `default` : `pointer`)};
   // input max-width, min-width 적용
   > div:first-of-type {
     max-width: 410px;

--- a/components/Atom/TimeLine/types.ts
+++ b/components/Atom/TimeLine/types.ts
@@ -4,12 +4,12 @@ export type TimeLineProps = {
   content?: TimeLineContentProps;
   moreButtonPositionCss?: EditDropdownProps['moreButtonPositionCss'];
   editListPositionCss?: EditDropdownProps['editListPositionCss'];
-  onSaveAllContent: (timeLineContent: TimeLineContentProps) => Promise<void>;
-  onDeleteContent: () => Promise<void>;
+  onSaveAllContent: (timeLineContent: TimeLineContentProps) => void;
+  onDeleteContent: () => void;
 };
 export type TimeLineContentProps = {
   date: string;
   title: string;
   desc: string;
-  img: string;
+  url: string;
 };


### PR DESCRIPTION
timeline 컴포넌트 수정하였습니다.

img 를 직접 props로 받지 않고 내려오는 url에 따라 기존에 만들어둔 블로그 svg로 보여주는 방식으로 변경하였고
수정 모드가 아닌 경우 area 클릭 시 새 탭으로 해당 url이 오픈되도록 수정하였습니다.

수정, 삭제 테스트 진행 후 정상 동작 확인 후 타입 정의 바꿔서 PR 올립니다

@jooa7878 @haryan248 