### PR TITLE
feat : user profile 페이지 서버사이드 렌더링 제거

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -7,8 +7,21 @@ import { Button } from '@/components/Atom/Button';
 import { useCallback } from 'react';
 import { useRouter } from 'next/router';
 import Icon404 from '@/assets/svgs/Icon404';
+import Spinner from '@/components/Atom/Spinner';
+import styles from '@/components/Molecules/OAuthLoading/OAuthLoading.styled';
 
-const Custom404 = () => {
+const Loading = () => {
+  return (
+    <div css={styles.loadingContainer}>
+      <div css={styles.spinnerContainer}>
+        <Spinner size='46px' />
+        <Typo.Body color={FONT_COLOR.WHITE}>Loading ... </Typo.Body>
+      </div>
+    </div>
+  );
+};
+
+const Custom404 = ({ isReady }: { isReady: boolean }) => {
   const device = useResize();
   const errorText = `앗, 페이지를 찾을 수 없습니다.\n입력한 주소를 다시 확인해 주세요.`;
   const router = useRouter();
@@ -16,7 +29,9 @@ const Custom404 = () => {
     router.push('/');
   }, [router]);
 
-  return (
+  return isReady ? (
+    <Loading />
+  ) : (
     <>
       <Custom404Wrapper>
         <ImageContainer>


### PR DESCRIPTION
**PR Type***
 - [ ] Bug
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactoring
 - [ ] Build related changes
 - [ ] CI related changes
 - [ ]  Documentation content changes
 - [ ]  Other... Please describe:

**Description**
FE팀 방에서 이야기 했듯, getServerSideProps 쪽 이슈로 인해
해당 함수 사용하지 않고 클라이언트 쪽에서 렌더링 진행
하지만 isError / isLoading 의 약간의 시차 때문에 404 페이지가 깜빡이는 이슈 발생
**Reviewers**
- [ ] @jooa7878 
- [x] @zerocy18 
- [ ] @haryan248
